### PR TITLE
add optional ignore devDependencies, false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           strict: true
           threshold: 500
+          ignore-dev-dependencies: true
 ```
 
 ## Options
@@ -37,4 +38,5 @@ jobs:
 | repo-token | used by the action in order to perform PR reviews  | true     |         |         |
 | strict     | If true will reject the PR if threshold is exceded | false    | Boolean | false   |
 | threshold  | Max package size in bytes                          | false    | String  | 500     |
+| ignore-dev-dependencies | Ignore devDependencies so that to not be checked | false    | Boolean  | false     |
 

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: "bundlephobia-checker"
 description: "Check for new packages and their sizes"
 branding:
-  icon: 'package'  
+  icon: 'package'
   color: 'black'
 inputs:
   repo-token: # id of input
@@ -12,6 +12,9 @@ inputs:
   threshold: # id of input
     description: "Maximum size in bytes of a package gziped"
     default: 600
+  ignore-dev-dependencies:
+    description: "Ignore devDependencies so that to not be checked"
+    default: false
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 const core = require("@actions/core");
+const fetch = require("node-fetch");
 
 exports.getMarkDownTable = (report) => {
     let table = `
@@ -49,3 +50,9 @@ exports.getMarkDownTable = (report) => {
         return `${pkname}@${versionParsed}`
     });
   }
+
+exports.getDevDependencies = async () => {
+  const result = await fetch(`https://raw.githubusercontent.com/${process.env.GITHUB_REPOSITORY}/${process.env.GITHUB_HEAD_REF}/package.json`);
+  const data = await result.json();
+  return data.devDependencies ? Object.keys(data.devDependencies) : [];
+}


### PR DESCRIPTION
Feature ✨

This PR implements a way to ignore devDependencies to be checked when the action triggers by adding a new property `ignore-dev-dependencies` which is false by default.